### PR TITLE
feat: replace OpenWeather with Open-Meteo

### DIFF
--- a/.config/hypr/scripts/quickshell/TopBar.qml
+++ b/.config/hypr/scripts/quickshell/TopBar.qml
@@ -299,17 +299,19 @@ Variants {
             Process {
                 id: weatherPoller
                 command: ["bash", "-c", `
-                    echo "$(~/.config/hypr/scripts/quickshell/calendar/weather.sh --current-icon)"
-                    echo "$(~/.config/hypr/scripts/quickshell/calendar/weather.sh --current-temp)"
-                    echo "$(~/.config/hypr/scripts/quickshell/calendar/weather.sh --current-hex)"
+                    icon=$(~/.config/hypr/scripts/quickshell/calendar/weather.sh --current-icon)
+                    temp=$(~/.config/hypr/scripts/quickshell/calendar/weather.sh --current-temp)
+                    hex=$(~/.config/hypr/scripts/quickshell/calendar/weather.sh --current-hex)
+                    echo "$icon|||$temp|||$hex"
                 `]
                 stdout: StdioCollector {
                     onStreamFinished: {
-                        let lines = this.text.trim().split("\n");
-                        if (lines.length >= 3) {
-                            barWindow.weatherIcon = lines[0];
-                            barWindow.weatherTemp = lines[1];
-                            barWindow.weatherHex = lines[2] || mocha.yellow;
+                        let txt = this.text.trim();
+                        let parts = txt.split("|||");
+                        if (parts.length >= 3) {
+                            if (parts[0].trim() !== "") barWindow.weatherIcon = parts[0].trim();
+                            if (parts[1].trim() !== "") barWindow.weatherTemp = parts[1].trim();
+                            if (parts[2].trim() !== "") barWindow.weatherHex = parts[2].trim();
                         }
                     }
                 }

--- a/.config/hypr/scripts/quickshell/calendar/weather.sh
+++ b/.config/hypr/scripts/quickshell/calendar/weather.sh
@@ -16,35 +16,33 @@ if [ -f "$ENV_FILE" ]; then
 fi
 
 # API Settings from .env
-KEY="$OPENWEATHER_KEY"
-ID="$OPENWEATHER_CITY_ID"
-UNIT="${OPENWEATHER_UNIT:-metric}" # Default to metric if not set
+LAT="$OPENMETEO_LAT"
+LON="$OPENMETEO_LON"
+UNIT="${OPENMETEO_UNIT:-celsius}" # Default to celsius if not set
 
 mkdir -p "${cache_dir}"
 
 get_icon() {
     case $1 in
-        "50d"|"50n") icon=""; quote="Mist" ;;
-        "01d") icon=""; quote="Sunny" ;;
-        "01n") icon=""; quote="Clear" ;;
-        "02d"|"02n"|"03d"|"03n"|"04d"|"04n") icon=""; quote="Cloudy" ;;
-        "09d"|"09n"|"10d"|"10n") icon=""; quote="Rainy" ;;
-        "11d"|"11n") icon=""; quote="Storm" ;;
-        "13d"|"13n") icon=""; quote="Snow" ;;
-        *) icon=""; quote="Unknown" ;;
+        0)             icon=""; quote="Sunny" ;;
+        1|2|3)         icon=""; quote="Cloudy" ;;
+        45|48)         icon=""; quote="Mist" ;;
+        51|53|55|61|63|65|80|81|82) icon=""; quote="Rainy" ;;
+        71|73|75|77)   icon=""; quote="Snow" ;;
+        95|96|99)      icon=""; quote="Storm" ;;
+        *)             icon=""; quote="Unknown" ;;
     esac
     echo "$icon|$quote"
 }
 
 get_hex() {
     case $1 in
-        "50d"|"50n") echo "#84afdb" ;;
-        "01d") echo "#f9e2af" ;;
-        "01n") echo "#cba6f7" ;;
-        "02d"|"02n"|"03d"|"03n"|"04d"|"04n") echo "#bac2de" ;;
-        "09d"|"09n"|"10d"|"10n") echo "#74c7ec" ;;
-        "11d"|"11n") echo "#f9e2af" ;;
-        "13d"|"13n") echo "#cdd6f4" ;;
+        0) echo "#f9e2af" ;;
+        1|2|3) echo "#bac2de" ;;
+        45|48) echo "#84afdb" ;;
+        51|53|55|61|63|65|80|81|82) echo "#74c7ec" ;;
+        71|73|75|77) echo "#cdd6f4" ;;
+        95|96|99) echo "#f9e2af" ;;
         *) echo "#cdd6f4" ;;
     esac
 }
@@ -68,10 +66,10 @@ write_dummy_data() {
             \"wind\": \"0\",
             \"humidity\": \"0\",
             \"pop\": \"0\",
-            \"icon\": \"\",
+            \"icon\": \"\",
             \"hex\": \"#cdd6f4\",
-            \"desc\": \"No API Key\",
-            \"hourly\": [{\"time\": \"00:00\", \"temp\": \"0.0\", \"icon\": \"\", \"hex\": \"#cdd6f4\"}]
+            \"desc\": \"No Coordinates\",
+            \"hourly\": [{\"time\": \"00:00\", \"temp\": \"0.0\", \"icon\": \"\", \"hex\": \"#cdd6f4\"}]
         },"
     done
     final_json="${final_json%,}]"
@@ -80,9 +78,9 @@ write_dummy_data() {
 
 get_data() {
     # ---------------------------------------------------------
-    # DUMMY DATA FALLBACK (If API key is missing or skipped)
+    # DUMMY DATA FALLBACK (If coordinates are missing or skipped)
     # ---------------------------------------------------------
-    if [[ -z "$KEY" || "$KEY" == "Skipped" || "$KEY" == "OPENWEATHER_KEY" ]]; then
+    if [[ -z "$LAT" || -z "$LON" || "$LAT" == "OPENMETEO_LAT" ]]; then
         write_dummy_data
         return
     fi
@@ -90,13 +88,11 @@ get_data() {
     # ---------------------------------------------------------
     # STANDARD API FETCH LOGIC
     # ---------------------------------------------------------
-    forecast_url="http://api.openweathermap.org/data/2.5/forecast?APPID=${KEY}&id=${ID}&units=${UNIT}"
+    forecast_url="https://api.open-meteo.com/v1/forecast?latitude=${LAT}&longitude=${LON}&hourly=temperature_2m,apparent_temperature,precipitation_probability,windspeed_10m,relativehumidity_2m,weathercode&daily=weathercode,temperature_2m_max,temperature_2m_min,precipitation_probability_max,windspeed_10m_max&temperature_unit=${UNIT}&windspeed_unit=kmh&forecast_days=5&timezone=auto"
     raw_api=$(curl -sf "$forecast_url")
-    
-    # Check if curl failed OR if OpenWeather returned an error (like 401 for pending keys)
-    api_cod=$(echo "$raw_api" | jq -r '.cod' 2>/dev/null)
-    
-    if [ -z "$raw_api" ] || [[ "$api_cod" != "200" ]]; then
+
+    # Check if curl failed OR if Open-Meteo returned an error
+    if [ -z "$raw_api" ] || echo "$raw_api" | jq -e '.error' &>/dev/null; then
         write_dummy_data
         return
     fi
@@ -106,20 +102,32 @@ get_data() {
 
     # 1. ROLLOVER CHECK
     if [ -f "$next_day_cache_file" ]; then
-        precache_date=$(cat "$next_day_cache_file" | jq -r '.[0].dt_txt' | cut -d' ' -f1)
+        precache_date=$(cat "$next_day_cache_file" | jq -r '.[0].time' | cut -dT -f1)
         if [ "$precache_date" == "$current_date" ]; then
             mv "$next_day_cache_file" "$daily_cache_file"
         fi
     fi
 
     # 2. PROCESS TODAY
-    api_today_items=$(echo "$raw_api" | jq -c ".list[] | select(.dt_txt | startswith(\"$current_date\"))" | jq -s '.')
+    api_today_items=$(echo "$raw_api" | jq -c ". as \$root | [
+        range(.hourly.time | length) | . as \$i |
+        select(\$root.hourly.time[\$i] | startswith(\"$current_date\")) |
+        {
+            time: \$root.hourly.time[\$i],
+            temp: \$root.hourly.temperature_2m[\$i],
+            feels_like: \$root.hourly.apparent_temperature[\$i],
+            wind: \$root.hourly.windspeed_10m[\$i],
+            humidity: \$root.hourly.relativehumidity_2m[\$i],
+            pop: \$root.hourly.precipitation_probability[\$i],
+            weathercode: \$root.hourly.weathercode[\$i]
+        }
+    ]")
 
     if [ -f "$daily_cache_file" ]; then
-        cached_date=$(cat "$daily_cache_file" | jq -r '.[0].dt_txt' | cut -d' ' -f1)
+        cached_date=$(cat "$daily_cache_file" | jq -r '.[0].time' | cut -dT -f1)
         if [ "$cached_date" == "$current_date" ]; then
             merged_today=$(echo "$api_today_items" | jq --slurpfile cache "$daily_cache_file" \
-                '($cache[0] + .) | unique_by(.dt) | sort_by(.dt)')
+                '($cache[0] + .) | unique_by(.time) | sort_by(.time)')
         else
             merged_today="$api_today_items"
         fi
@@ -130,64 +138,101 @@ get_data() {
     echo "$merged_today" > "$daily_cache_file"
 
     # 3. PRE-CACHE TOMORROW
-    api_tomorrow_items=$(echo "$raw_api" | jq -c ".list[] | select(.dt_txt | startswith(\"$tomorrow_date\"))" | jq -s '.')
+    api_tomorrow_items=$(echo "$raw_api" | jq -c ". as \$root | [
+        range(.hourly.time | length) | . as \$i |
+        select(\$root.hourly.time[\$i] | startswith(\"$tomorrow_date\")) |
+        {
+            time: \$root.hourly.time[\$i],
+            temp: \$root.hourly.temperature_2m[\$i],
+            feels_like: \$root.hourly.apparent_temperature[\$i],
+            wind: \$root.hourly.windspeed_10m[\$i],
+            humidity: \$root.hourly.relativehumidity_2m[\$i],
+            pop: \$root.hourly.precipitation_probability[\$i],
+            weathercode: \$root.hourly.weathercode[\$i]
+        }
+    ]")
     echo "$api_tomorrow_items" > "$next_day_cache_file"
 
     # 4. BUILD FINAL JSON
-    processed_forecast=$(echo "$raw_api" | jq --argjson today "$merged_today" --arg date "$current_date" \
-        '.list = ($today + [.list[] | select(.dt_txt | startswith($date) | not)])')
-
-    if [ ! -z "$processed_forecast" ]; then
-        dates=$(echo "$processed_forecast" | jq -r '.list[].dt_txt | split(" ")[0]' | uniq | head -n 5)
-        
+    if [ ! -z "$raw_api" ]; then
         final_json="["
         counter=0
-        
-        for d in $dates; do
-            day_data=$(echo "$processed_forecast" | jq "[.list[] | select(.dt_txt | startswith(\"$d\"))]")
 
-            raw_max=$(echo "$day_data" | jq '[.[].main.temp_max] | max')
+        for i in $(seq 0 4); do
+            d=$(echo "$raw_api" | jq -r ".daily.time[$i]")
+            [ "$d" == "null" ] && continue
+
+            wmo_code=$(echo "$raw_api" | jq -r ".daily.weathercode[$i]")
+
+            raw_max=$(echo "$raw_api" | jq -r ".daily.temperature_2m_max[$i]")
             f_max_temp=$(printf "%.1f" "$raw_max")
 
-            raw_min=$(echo "$day_data" | jq '[.[].main.temp_min] | min')
+            raw_min=$(echo "$raw_api" | jq -r ".daily.temperature_2m_min[$i]")
             f_min_temp=$(printf "%.1f" "$raw_min")
 
-            raw_feels=$(echo "$day_data" | jq '[.[].main.feels_like] | max')
+            # Use today's merged hourly cache for feels_like, otherwise pull from hourly array
+            if [ "$d" == "$current_date" ] && [ -f "$daily_cache_file" ]; then
+                raw_feels=$(cat "$daily_cache_file" | jq '[.[].feels_like] | max')
+            else
+                raw_feels=$(echo "$raw_api" | jq ". as \$root | [
+                    range(.hourly.time | length) | . as \$i |
+                    select(\$root.hourly.time[\$i] | startswith(\"$d\")) |
+                    \$root.hourly.apparent_temperature[\$i]
+                ] | max")
+            fi
             f_feels_like=$(printf "%.1f" "$raw_feels")
 
-            f_pop=$(echo "$day_data" | jq '[.[].pop] | max')
-            f_pop_pct=$(echo "$f_pop * 100" | bc | cut -d. -f1)
-            f_wind=$(echo "$day_data" | jq '[.[].wind.speed] | max | round')
-            f_hum=$(echo "$day_data" | jq '[.[].main.humidity] | add / length | round')
-            
-            f_code=$(echo "$day_data" | jq -r '.[length/2 | floor].weather[0].icon')
-            f_desc=$(echo "$day_data" | jq -r '.[length/2 | floor].weather[0].description' | sed -e "s/\b\(.\)/\u\1/g")
-            f_icon_data=$(get_icon "$f_code")
+            f_pop_pct=$(echo "$raw_api" | jq -r ".daily.precipitation_probability_max[$i]")
+            f_wind=$(echo "$raw_api" | jq -r ".daily.windspeed_10m_max[$i] | round")
+
+            # Humidity comes from hourly — average across the day
+            f_hum=$(echo "$raw_api" | jq ". as \$root | [
+                range(.hourly.time | length) | . as \$i |
+                select(\$root.hourly.time[\$i] | startswith(\"$d\")) |
+                \$root.hourly.relativehumidity_2m[\$i]
+            ] | add / length | round")
+
+            f_icon_data=$(get_icon "$wmo_code")
             f_icon=$(echo "$f_icon_data" | cut -d'|' -f1)
-            f_hex=$(get_hex "$f_code")
-            
+            f_desc=$(echo "$f_icon_data" | cut -d'|' -f2)
+            f_hex=$(get_hex "$wmo_code")
+
             f_day=$(date -d "$d" "+%a")
             f_full_day=$(date -d "$d" "+%A")
             f_date_num=$(date -d "$d" "+%d %b")
 
-            hourly_json="["
-            count_slots=$(echo "$day_data" | jq '. | length')
-            count_slots=$((count_slots-1))
-            
-            for i in $(seq 0 1 $count_slots); do
-                slot_item=$(echo "$day_data" | jq ".[$i]")
-                
-                raw_s_temp=$(echo "$slot_item" | jq ".main.temp")
-                s_temp=$(printf "%.1f" "$raw_s_temp")
-                
-                s_dt=$(echo "$slot_item" | jq ".dt")
-                s_time=$(date -d @$s_dt "+%H:%M")
-                s_code=$(echo "$slot_item" | jq -r ".weather[0].icon")
-                s_hex=$(get_hex "$s_code")
-                s_icon=$(get_icon "$s_code" | cut -d'|' -f1)
-                
-                hourly_json="${hourly_json} {\"time\": \"${s_time}\", \"temp\": \"${s_temp}\", \"icon\": \"${s_icon}\", \"hex\": \"${s_hex}\"},"
-            done
+            # Build hourly slots — use merged cache for today, raw API for other days
+            if [ "$d" == "$current_date" ] && [ -f "$daily_cache_file" ]; then
+                hourly_source=$(cat "$daily_cache_file")
+                count_slots=$(echo "$hourly_source" | jq '. | length - 1')
+                hourly_json="["
+                for j in $(seq 0 1 $count_slots); do
+                    slot_item=$(echo "$hourly_source" | jq ".[$j]")
+                    raw_s_temp=$(echo "$slot_item" | jq ".temp")
+                    s_temp=$(printf "%.1f" "$raw_s_temp")
+                    s_time=$(echo "$slot_item" | jq -r ".time" | cut -dT -f2 | cut -d: -f1,2)
+                    s_code=$(echo "$slot_item" | jq -r ".weathercode")
+                    s_hex=$(get_hex "$s_code")
+                    s_icon=$(get_icon "$s_code" | cut -d'|' -f1)
+                    hourly_json="${hourly_json} {\"time\": \"${s_time}\", \"temp\": \"${s_temp}\", \"icon\": \"${s_icon}\", \"hex\": \"${s_hex}\"},"
+                done
+            else
+                hourly_indices=$(echo "$raw_api" | jq -r ". as \$root | [
+                    range(.hourly.time | length) | . as \$i |
+                    select(\$root.hourly.time[\$i] | startswith(\"$d\")) |
+                    \$i
+                ][]")
+                hourly_json="["
+                for j in $hourly_indices; do
+                    raw_s_temp=$(echo "$raw_api" | jq -r ".hourly.temperature_2m[$j]")
+                    s_temp=$(printf "%.1f" "$raw_s_temp")
+                    s_time=$(echo "$raw_api" | jq -r ".hourly.time[$j]" | cut -dT -f2 | cut -d: -f1,2)
+                    s_code=$(echo "$raw_api" | jq -r ".hourly.weathercode[$j]")
+                    s_hex=$(get_hex "$s_code")
+                    s_icon=$(get_icon "$s_code" | cut -d'|' -f1)
+                    hourly_json="${hourly_json} {\"time\": \"${s_time}\", \"temp\": \"${s_temp}\", \"icon\": \"${s_icon}\", \"hex\": \"${s_hex}\"},"
+                done
+            fi
             hourly_json="${hourly_json%,}]"
 
             final_json="${final_json} {
@@ -219,8 +264,7 @@ if [[ "$1" == "--getdata" ]]; then
     get_data
 
 elif [[ "$1" == "--json" ]]; then
-    CACHE_LIMIT=900         # 15 minutes for valid working data
-    PENDING_RETRY_LIMIT=3600 # 1 hour for invalid/activating keys
+    CACHE_LIMIT=900          # 15 minutes for valid working data
 
     # Check if .env file has been modified since we last checked
     env_changed=0
@@ -241,16 +285,10 @@ elif [[ "$1" == "--json" ]]; then
         
         if [ "$env_changed" -eq 1 ]; then
             # The user just modified the .env file. Bypass cache entirely.
-            touch "$json_file" 
+            touch "$json_file"
             get_data &
-        elif grep -q '"desc": "No API Key"' "$json_file"; then
-            # Key is pending/invalid. Check once an hour.
-            if [ $diff -gt $PENDING_RETRY_LIMIT ]; then
-                touch "$json_file" # Bump file timestamp slightly to avoid spamming processes
-                get_data &
-            fi
         else
-            # Normal working API key. Check every 15 mins.
+            # Open-Meteo needs no key activation wait. Check every 15 mins.
             if [ $diff -gt $CACHE_LIMIT ]; then
                 touch "$json_file"
                 get_data &
@@ -284,26 +322,32 @@ elif [[ "$1" == "--nav" ]]; then
     fi
 
 elif [[ "$1" == "--icon" ]]; then
+    [ ! -f "$json_file" ] && get_data
     cat "$json_file" | jq -r '.forecast[0].icon'
 
 elif [[ "$1" == "--temp" ]]; then 
+    [ ! -f "$json_file" ] && get_data
     t=$(cat "$json_file" | jq -r '.forecast[0].max')
     echo "${t}°C"
 
 elif [[ "$1" == "--hex" ]]; then 
+    [ ! -f "$json_file" ] && get_data
     cat "$json_file" | jq -r '.forecast[0].hex'
 
 # --- NEW HOURLY MODES FOR TOPBAR ---
 elif [[ "$1" == "--current-icon" ]]; then
+    [ ! -f "$json_file" ] && get_data
     curr_time=$(date +%H:%M)
     cat "$json_file" | jq -r --arg ct "$curr_time" '(.forecast[0].hourly | map(select(.time <= $ct)) | last) // .forecast[0].hourly[0] | .icon'
 
 elif [[ "$1" == "--current-temp" ]]; then 
+    [ ! -f "$json_file" ] && get_data
     curr_time=$(date +%H:%M)
     t=$(cat "$json_file" | jq -r --arg ct "$curr_time" '(.forecast[0].hourly | map(select(.time <= $ct)) | last) // .forecast[0].hourly[0] | .temp')
     echo "${t}°C"
 
 elif [[ "$1" == "--current-hex" ]]; then
+    [ ! -f "$json_file" ] && get_data
     curr_time=$(date +%H:%M)
     cat "$json_file" | jq -r --arg ct "$curr_time" '(.forecast[0].hourly | map(select(.time <= $ct)) | last) // .forecast[0].hourly[0] | .hex'
 fi

--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,8 @@ VERSION_FILE="$HOME/.local/state/imperative-dots-version"
 
 # Global Variables & Initial States (Defaults)
 WALLPAPER_DIR="$(xdg-user-dir PICTURES 2>/dev/null || echo "$HOME/Pictures")/Wallpapers"
-WEATHER_API_KEY=""
-WEATHER_CITY_ID=""
+WEATHER_LAT=""
+WEATHER_LON=""
 WEATHER_UNIT=""
 FAILED_PKGS=()
 
@@ -46,7 +46,14 @@ if [ -f "$VERSION_FILE" ]; then
     source "$VERSION_FILE"
     if [ -n "$LOCAL_VERSION" ]; then
         if [ -n "$KB_LAYOUTS" ]; then VISITED_KEYBOARD=true; fi
-        if [ -n "$WEATHER_API_KEY" ]; then VISITED_WEATHER=true; fi
+        # old version files used OpenWeather API keys and OpenWeather City ID's so the user should reconfigure
+        if [ -n "$WEATHER_API_KEY" ] && [ -z "$WEATHER_LAT" ]; then
+            WEATHER_LAT=""
+            WEATHER_LON=""
+            VISITED_WEATHER=false
+        elif [ -n "$WEATHER_LAT" ] && [ "$WEATHER_LAT" != "Skipped" ]; then
+            VISITED_WEATHER=true
+        fi
         if [ "$DRIVER_CHOICE" != "None (Skipped)" ] && [ -n "$DRIVER_CHOICE" ]; then VISITED_DRIVERS=true; fi
     fi
 else
@@ -569,39 +576,51 @@ show_overview() {
 set_weather_api() {
     while true; do
         draw_header
-        echo -e "${BOLD}${C_CYAN}=== OpenWeatherMap Interactive Setup ===${RESET}"
-        
+        echo -e "${BOLD}${C_CYAN}=== Open-Meteo Interactive Setup ===${RESET}"
+
         ENV_FILE="$HOME/.config/hypr/scripts/quickshell/calendar/.env"
-        
-        if [ -f "$ENV_FILE" ] || [[ -n "$WEATHER_API_KEY" && "$WEATHER_API_KEY" != "Skipped" ]]; then
-            echo -e "${C_GREEN}An existing Weather configuration (.env) was detected.${RESET}"
-            echo -e "${BOLD}${C_YELLOW}Press ENTER without typing anything to KEEP your existing configuration.${RESET}\n"
-        else
-            echo -e "${BOLD}${C_YELLOW}Without this, weather widgets WILL NOT WORK.${RESET}\n"
-            echo -e "${C_MAGENTA}How to get a free API key:${RESET}"
-            echo -e "  1. Visit ${C_BLUE}https://openweathermap.org/${RESET}"
-            echo -e "  2. Create a free account and log in."
-            echo -e "  3. Click your profile name -> 'My API keys'."
-            echo -e "  4. Generate a new key and paste it below."
-            echo -e "  ${BOLD}${C_YELLOW}Note: New API keys may take a couple of hours to activate. This installer will NOT block you from using a fresh key.${RESET}\n"
+
+        local has_valid_env=false
+        local has_old_env=false
+        if [ -f "$ENV_FILE" ]; then
+            if grep -q "OPENMETEO_LAT" "$ENV_FILE" 2>/dev/null; then
+                has_valid_env=true
+            elif grep -q "OPENWEATHER_KEY" "$ENV_FILE" 2>/dev/null; then
+                has_old_env=true
+            fi
         fi
-        
-        read -p "Enter your OpenWeather API Key (or press Enter to skip/keep): " input_key
-        
-        if [[ -z "$input_key" ]]; then
-            if [ -f "$ENV_FILE" ] || [[ -n "$WEATHER_API_KEY" && "$WEATHER_API_KEY" != "Skipped" ]]; then
-                echo -e "\n${C_GREEN}Keeping existing weather configuration.${RESET}"
+
+        if $has_valid_env || [[ -n "$WEATHER_LAT" && "$WEATHER_LAT" != "Skipped" ]]; then
+            echo -e "${C_GREEN}An existing Open-Meteo configuration was detected.${RESET}"
+            echo -e "${BOLD}${C_YELLOW}Press ENTER without typing anything to KEEP your existing configuration.${RESET}\n"
+        elif $has_old_env; then
+            echo -e "${C_YELLOW}An old OpenWeather .env was detected. It cannot be auto-migrated (City ID ≠ Lat/Lon).${RESET}"
+            echo -e "${C_YELLOW}Please search for your city below to create a new Open-Meteo config.${RESET}\n"
+        else
+            echo -e "${C_GREEN}Open-Meteo is completely free - no API key required.${RESET}"
+            echo -e "${BOLD}${C_YELLOW}Without this, weather widgets will not show correctly.${RESET}\n"
+        fi
+
+        read -p "Enter city name to search (or press Enter to skip/keep): " input_city
+
+        if [[ -z "$input_city" ]]; then
+            if $has_valid_env || [[ -n "$WEATHER_LAT" && "$WEATHER_LAT" != "Skipped" ]]; then
+                echo -e "\n${C_GREEN}Keeping existing Open-Meteo configuration.${RESET}"
                 KEEP_OLD_ENV=true
                 VISITED_WEATHER=true
                 sleep 1.5
                 break
+            elif $has_old_env; then
+                echo -e "\n${C_RED}Old OpenWeather config cannot be kept — please search for your city to migrate.${RESET}"
+                sleep 2
+                continue
             else
-                echo -e "\n${C_RED}WARNING: You did not enter an API key.${RESET}"
-                echo -n -e "Are you ${BOLD}${C_RED}100% sure${RESET} you want to proceed without it? (y/n): "
+                echo -e "\n${C_RED}WARNING: You did not enter a city.${RESET}"
+                echo -n -e "Are you ${BOLD}${C_RED}100% sure${RESET} you want to proceed without weather? (y/n): "
                 read -r confirm
                 if [[ "$confirm" =~ ^[Yy]$ ]]; then
-                    WEATHER_API_KEY="Skipped"
-                    WEATHER_CITY_ID=""
+                    WEATHER_LAT="Skipped"
+                    WEATHER_LON=""
                     WEATHER_UNIT=""
                     KEEP_OLD_ENV=false
                     VISITED_WEATHER=true
@@ -611,52 +630,72 @@ set_weather_api() {
             fi
         fi
 
-        # Soft validation to ensure it looks like a valid key without querying the API
-        input_key=$(echo "$input_key" | tr -d ' ')
-        if [[ ${#input_key} -ne 32 ]]; then
-            echo -e "\n${C_YELLOW}Warning: OpenWeather API keys are typically exactly 32 characters long.${RESET}"
-            echo -e "${C_YELLOW}Your key is ${#input_key} characters long.${RESET}"
-            echo -n "Are you sure this key is correct? (y/n): "
-            read -r confirm_key
-            if [[ ! "$confirm_key" =~ ^[Yy]$ ]]; then
-                continue
-            fi
-        fi
-        
-        WEATHER_API_KEY="$input_key"
-        
-        echo -e "\n${C_CYAN}Let's set your location using your City ID.${RESET}"
-        echo -e "1. Go to ${C_BLUE}https://openweathermap.org/${RESET} and search for your city."
-        echo -e "2. Look at the URL in your browser. It will look something like this:"
-        echo -e "   ${DIM}https://openweathermap.org/city/${RESET}${BOLD}2643743${RESET}"
-        echo -e "3. Copy that number at the end (the City ID) and paste it below.\n"
-        
-        read -p "Enter City ID: " input_id
+        # use Open-Meteo Geocoding API to get citys and find LAT and LON
+        echo -e "\n${C_CYAN}Searching for '${input_city}'...${RESET}"
+        local encoded_city="${input_city// /+}"
+        local geo_response
+        geo_response=$(curl -fsSL \
+            "https://geocoding-api.open-meteo.com/v1/search?name=${encoded_city}&count=10&language=en&format=json" \
+            2>/dev/null)
 
-        if [[ -z "$input_id" || ! "$input_id" =~ ^[0-9]+$ ]]; then
-            echo -e "${C_RED}Invalid City ID. It must be a number.${RESET}"
+        if [[ -z "$geo_response" ]]; then
+            echo -e "${C_RED}Network error — could not reach geocoding-api.open-meteo.com. Check your connection.${RESET}"
+            sleep 2
+            continue
+        fi
+
+        if ! echo "$geo_response" | jq -e '.results' > /dev/null 2>&1 || \
+           [[ "$(echo "$geo_response" | jq '.results | length')" -eq 0 ]]; then
+            echo -e "${C_RED}No cities found for '${input_city}'. Try a different spelling or broader name.${RESET}"
             sleep 1.5
             continue
         fi
 
-        WEATHER_CITY_ID="$input_id"
-        
-        # Ask for standard units
-        echo ""
-        unit_choice=$(echo -e "metric (Celsius)\nimperial (Fahrenheit)\nstandard (Kelvin)" | fzf \
+        local city_list
+        city_list=$(echo "$geo_response" | jq -r \
+            '.results[] | "\(.name), \(.admin1 // "-"), \(.country) [LAT:\(.latitude) LON:\(.longitude)]"')
+
+        local selected
+        selected=$(echo "$city_list" | fzf \
             --layout=reverse \
             --border=rounded \
             --margin=1,2 \
-            --height=12 \
+            --height=16 \
+            --prompt=" Select City > " \
+            --pointer=">" \
+            --header=" Select your city — use ARROW KEYS and ENTER, ESC to search again ")
+
+        [[ -z "$selected" ]] && continue
+
+        local lat lon
+        lat=$(echo "$selected" | grep -oP 'LAT:[-0-9.]+' | cut -d: -f2)
+        lon=$(echo "$selected" | grep -oP 'LON:[-0-9.]+' | cut -d: -f2)
+
+        if [[ -z "$lat" || -z "$lon" ]]; then
+            echo -e "${C_RED}Failed to parse coordinates from selection. Please try again.${RESET}"
+            sleep 1.5
+            continue
+        fi
+
+        WEATHER_LAT="$lat"
+        WEATHER_LON="$lon"
+
+        # OpenMeteo does not support kelvin.
+        echo ""
+        local unit_choice
+        unit_choice=$(echo -e "celsius\nfahrenheit" | fzf \
+            --layout=reverse \
+            --border=rounded \
+            --margin=1,2 \
+            --height=8 \
             --prompt=" Select Temperature Unit > " \
             --pointer=">" \
-            --header=" Choose your preferred unit format ")
-        
-        WEATHER_UNIT=$(echo "$unit_choice" | awk '{print $1}')
-        [[ -z "$WEATHER_UNIT" ]] && WEATHER_UNIT="metric"
-        
+            --header=" Choose your preferred unit ")
+
+        WEATHER_UNIT="${unit_choice:-celsius}"
         KEEP_OLD_ENV=false
-        echo -e "\n${C_GREEN}Weather configuration complete! Widget will update once your key is activated by OpenWeather.${RESET}"
+
+        echo -e "\n${C_GREEN}Open-Meteo configured! Location: ${selected%% [LAT*]} | Coords: ${lat}, ${lon} | Unit: ${WEATHER_UNIT}${RESET}"
         sleep 2.5
         VISITED_WEATHER=true
         break
@@ -810,19 +849,22 @@ while true; do
     S_KBD=$( [ "$VISITED_KEYBOARD" = true ] && echo -e "${C_GREEN}[✓]${RESET}" || echo -e "${C_RED}[ ]${RESET}" )
     S_TEL=$( [ "$ENABLE_TELEMETRY" = true ] && echo -e "${C_GREEN}[ON]${RESET}" || echo -e "${DIM}[OFF]${RESET}" )
 
-    if [[ -z "$WEATHER_API_KEY" ]]; then
-        if [ -f "$HOME/.config/hypr/scripts/quickshell/calendar/.env" ]; then
+    _env_check="$HOME/.config/hypr/scripts/quickshell/calendar/.env"
+    if [[ -z "$WEATHER_LAT" || "$WEATHER_LAT" == "" ]]; then
+        if [ -f "$_env_check" ] && grep -q "OPENMETEO_LAT" "$_env_check" 2>/dev/null; then
             API_DISPLAY="Set (from .env file)"
+        elif [ -f "$_env_check" ] && grep -q "OPENWEATHER_KEY" "$_env_check" 2>/dev/null; then
+            API_DISPLAY="${C_YELLOW}Needs Migration${RESET}"
         else
             API_DISPLAY="Not Set"
         fi
-    elif [[ "$WEATHER_API_KEY" == "Skipped" ]]; then API_DISPLAY="Skipped"
-    else API_DISPLAY="Set ($WEATHER_UNIT, ID: $WEATHER_CITY_ID)"; fi
+    elif [[ "$WEATHER_LAT" == "Skipped" ]]; then API_DISPLAY="Skipped"
+    else API_DISPLAY="Set ($WEATHER_UNIT, ${WEATHER_LAT}/${WEATHER_LON})"; fi
 
     # Build the color-coded menu string
     MENU_ITEMS="1. $S_PKG ${C_GREEN}Manage Packages${RESET} [${#PKGS[@]} queued, Optional]\n"
     MENU_ITEMS+="2. $S_OVW ${C_CYAN}Overview & Keybinds${RESET} [Optional]\n"
-    MENU_ITEMS+="3. $S_WTH ${C_YELLOW}Set Weather API Key${RESET} [${API_DISPLAY}, Optional]\n"
+    MENU_ITEMS+="3. $S_WTH ${C_YELLOW}Set Weather Configuration${RESET} [${API_DISPLAY}, Optional]\n"
     MENU_ITEMS+="4. $S_DRV ${C_RED}[ DRIVERS ] Setup${RESET} [${DRIVER_CHOICE}, Optional]\n"
     MENU_ITEMS+="5. $S_KBD ${C_BLUE}Keyboard Layout Setup${RESET} [${KB_LAYOUTS_DISPLAY:-$KB_LAYOUTS}]\n"
     MENU_ITEMS+="6. $S_TEL ${C_CYAN}Telemetry Settings${RESET}\n"
@@ -1124,35 +1166,41 @@ fi
 ENV_TARGET_DIR="$TARGET_CONFIG_DIR/hypr/scripts/quickshell/calendar"
 OLD_ENV_IN_BACKUP="$BACKUP_DIR/hypr/scripts/quickshell/calendar/.env"
 
+_write_openmeteo_env() {
+    local target_dir="$1"
+    mkdir -p "$target_dir"
+    cat <<EOF > "$target_dir/.env"
+# OpenMeteo Configuration
+OPENMETEO_LAT=${WEATHER_LAT}
+OPENMETEO_LON=${WEATHER_LON}
+OPENMETEO_UNIT=${WEATHER_UNIT}
+EOF
+    chmod 600 "$target_dir/.env"
+}
+
 if [[ "$KEEP_OLD_ENV" == true ]]; then
     if [ -f "$OLD_ENV_IN_BACKUP" ]; then
-        mkdir -p "$ENV_TARGET_DIR"
-        cp "$OLD_ENV_IN_BACKUP" "$ENV_TARGET_DIR/.env"
-        printf "  -> Restored existing Weather API config from backup %-3s ${C_GREEN}[ OK ]${RESET}\n" ""
+        # Migrate old OpenWeather backup to Open-Meteo format if needed
+        if grep -q "OPENWEATHER_KEY" "$OLD_ENV_IN_BACKUP" 2>/dev/null; then
+            echo -e "  -> ${C_YELLOW}Old OpenWeather backup detected — cannot auto-migrate. Re-run setup to configure weather.${RESET}"
+        else
+            mkdir -p "$ENV_TARGET_DIR"
+            cp "$OLD_ENV_IN_BACKUP" "$ENV_TARGET_DIR/.env"
+            printf "  -> Restored existing Open-Meteo config from backup %-3s ${C_GREEN}[ OK ]${RESET}\n" ""
+        fi
     elif [ -f "$ENV_TARGET_DIR/.env" ]; then
-        printf "  -> Retained existing Weather API config %-13s ${C_GREEN}[ OK ]${RESET}\n" ""
-    elif [[ -n "$WEATHER_API_KEY" && "$WEATHER_API_KEY" != "Skipped" ]]; then
-        # Fallback if file doesn't exist but we have the vars loaded from version file
-        mkdir -p "$ENV_TARGET_DIR"
-        cat <<EOF > "$ENV_TARGET_DIR/.env"
-# OpenWeather API Configuration
-OPENWEATHER_KEY=${WEATHER_API_KEY}
-OPENWEATHER_CITY_ID=${WEATHER_CITY_ID}
-OPENWEATHER_UNIT=${WEATHER_UNIT}
-EOF
-        chmod 600 "$ENV_TARGET_DIR/.env"
-        printf "  -> Regenerated Weather API config from cache %-7s ${C_GREEN}[ OK ]${RESET}\n" ""
+        if grep -q "OPENWEATHER_KEY" "$ENV_TARGET_DIR/.env" 2>/dev/null; then
+            echo -e "  -> ${C_YELLOW}Old OpenWeather .env found — cannot auto-migrate. Re-run setup to configure weather.${RESET}"
+        else
+            printf "  -> Retained existing Open-Meteo config %-13s ${C_GREEN}[ OK ]${RESET}\n" ""
+        fi
+    elif [[ -n "$WEATHER_LAT" && "$WEATHER_LAT" != "Skipped" ]]; then
+        _write_openmeteo_env "$ENV_TARGET_DIR"
+        printf "  -> Regenerated Open-Meteo config from cache %-7s ${C_GREEN}[ OK ]${RESET}\n" ""
     fi
-elif [[ -n "$WEATHER_API_KEY" && "$WEATHER_API_KEY" != "Skipped" ]]; then
-    mkdir -p "$ENV_TARGET_DIR"
-    cat <<EOF > "$ENV_TARGET_DIR/.env"
-# OpenWeather API Configuration
-OPENWEATHER_KEY=${WEATHER_API_KEY}
-OPENWEATHER_CITY_ID=${WEATHER_CITY_ID}
-OPENWEATHER_UNIT=${WEATHER_UNIT}
-EOF
-    chmod 600 "$ENV_TARGET_DIR/.env"
-    printf "  -> Saved Weather API config to .env %-7s ${C_GREEN}[ OK ]${RESET}\n" ""
+elif [[ -n "$WEATHER_LAT" && "$WEATHER_LAT" != "Skipped" ]]; then
+    _write_openmeteo_env "$ENV_TARGET_DIR"
+    printf "  -> Saved Open-Meteo config to .env %-14s ${C_GREEN}[ OK ]${RESET}\n" ""
 fi
 
 # Deploy Cava Wrapper
@@ -1401,8 +1449,8 @@ fi
 cat <<EOF > "$VERSION_FILE"
 LOCAL_VERSION="$DOTS_VERSION"
 LAST_COMMIT="$NEW_COMMIT"
-WEATHER_API_KEY="$WEATHER_API_KEY"
-WEATHER_CITY_ID="$WEATHER_CITY_ID"
+WEATHER_LAT="$WEATHER_LAT"
+WEATHER_LON="$WEATHER_LON"
 WEATHER_UNIT="$WEATHER_UNIT"
 DRIVER_CHOICE="$DRIVER_CHOICE"
 KB_LAYOUTS="$KB_LAYOUTS"


### PR DESCRIPTION
Replacing OpenWeather with Open-Meteo so users dont have to get an API key. #11
Now i have to say, I dont think Open-Meteo is as accurate as OpenWeather. 

But its easier for users that dont want to wait 2 hours for their API key to start working.
I've tested the Install script in a VM and im pretty sure it works, but i couldn't test that much since Hyprland HATES VM's and crashes every second so it may need a bit more testing.
And users type their City Name instead of getting a City ID, Which is then converted into latitude and longitude for Open-Meteo. Kelvin is not supported in Open-Meteo unfortunately.