### PR TITLE
fix: adapt screenshot area

### DIFF
--- a/.config/hypr/scripts/quickshell/ScreenshotOverlay.qml
+++ b/.config/hypr/scripts/quickshell/ScreenshotOverlay.qml
@@ -16,10 +16,11 @@ PanelWindow {
     
     exclusionMode: ExclusionMode.Ignore 
     focusable: true
-    width: Screen.width
-    height: Screen.height
+    screen: Quickshell.cursorScreen
+    width: screen.width
+    height: screen.height
 
-    Scaler { id: scaler; currentWidth: Screen.width }
+    Scaler { id: scaler; currentWidth: width }
     function s(val) { return scaler.s(val); }
     
     MatugenColors { id: _theme }


### PR DESCRIPTION
# Issue

The screenshot tool didnt utilize the full space for the selection of the screenshot on my widescreen. Therefore I adapted the ScreenshotOverlay to use the current active cursor screen and to use the screens size to adapt to. Not quite sure why the Screen object didnt provide the correct values.