### PR TITLE
Fix: No running polkit agent so programs that require elevated permissions silently fail.

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -30,6 +30,7 @@ env = NIXOS_OZONE_WL,1
 #  ◈ AUTOSTART
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+exec-once = systemctl --user start hyprpolkitagent
 exec-once = awww-daemon
 exec-once = hypridle
 exec-once = quickshell -p ~/.config/hypr/scripts/quickshell/Main.qml

--- a/install.sh
+++ b/install.sh
@@ -99,7 +99,7 @@ ARCH_PKGS=(
     "imagemagick" "wget" "file" "git" "psmisc"
     "matugen-bin" "ffmpeg" "fastfetch" "quickshell-git" "unzip" "python-websockets" "qt6-websockets"
     "grim" "playerctl" "satty" "yq" "xdg-desktop-portal-gtk" "slurp" "mpvpaper"
-    "wmctrl" "power-profiles-daemon" "easyeffects" "swayosd-git" "nautilus" "lsp-plugins"
+    "wmctrl" "power-profiles-daemon" "easyeffects" "swayosd-git" "nautilus" "lsp-plugins" "hyprpolkitagent"
     "qt5-wayland" "qt5-quickcontrols" "qt5-quickcontrols2" "qt5-graphicaleffects" "qt6-wayland"
 )
 


### PR DESCRIPTION
Added start command for hyprpolkitagent in hyprland.conf and added it as a dependency in installer.