### PR TITLE
Fix: logout sometimes results in hanging black screen

### DIFF
--- a/.config/hypr/scripts/quickshell/battery/BatteryPopup.qml
+++ b/.config/hypr/scripts/quickshell/battery/BatteryPopup.qml
@@ -784,7 +784,7 @@ Item {
                             anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
                             onClicked: { 
                                 exitAnim.start(); // Trigger graceful UI exit
-                                Quickshell.execDetached(["sh", "-c", "loginctl kill-session $XDG_SESSION_ID"]); 
+                                Quickshell.execDetached(["sh", "-c", "hyprctl dispatch exit & sleep 1 && loginctl terminate-session $XDG_SESSION_ID"]);
                                 Quickshell.execDetached(["sh", "-c", "echo 'close' > /tmp/qs_widget_state"]); 
                             }
                         }

--- a/.config/hypr/scripts/quickshell/battery/BatteryPopupAlt.qml
+++ b/.config/hypr/scripts/quickshell/battery/BatteryPopupAlt.qml
@@ -808,7 +808,7 @@ Item {
                             anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
                             onClicked: { 
                                 exitAnim.start(); // Trigger graceful UI exit
-                                Quickshell.execDetached(["sh", "-c", "loginctl kill-session $XDG_SESSION_ID"]); 
+                                Quickshell.execDetached(["sh", "-c", "hyprctl dispatch exit & sleep 1 && loginctl terminate-session $XDG_SESSION_ID"]);
                                 Quickshell.execDetached(["sh", "-c", "echo 'close' > /tmp/qs_widget_state"]); 
                             }
                         }


### PR DESCRIPTION
Some users report a hanging black screen after logging out. This seems to be due to `loginctl kill-session` abruptly SIGKILLing the session and not giving SDDM and other system processes/services time to react. By switching to `hyprctl dispatch exit` and `loginctl terminate-session`, we cleanly exit hyprland and then clean up D-BUS/systemd user services as `terminate-session` uses SIGTERM.