### PR TITLE
feat: add matugen colors for music

### DIFF
--- a/.config/hypr/scripts/quickshell/music/music_info.sh
+++ b/.config/hypr/scripts/quickshell/music/music_info.sh
@@ -143,6 +143,21 @@ if [ "$STATUS" = "Playing" ] || [ "$STATUS" = "Paused" ]; then
         dev_icon="󰓃"; dev_name="System"
     fi
 
+    # --- 6.5. Matugen Colors ---
+    if { [ "$STATUS" = "Playing" ] || [ "$STATUS" = "Paused" ]; } && [ -f "$displayArt" ]; then
+        /bin/matugen image "$displayArt" --source-color-index 0
+    else
+        if [ -e ~/.cache/current_wallpaper.png ]; then
+            /bin/matugen image ~/.cache/current_wallpaper.png --source-color-index 0
+        else
+            WALLPAPER=$(awww query | sed -n 's/.*image: //p' | head -n1)
+
+            if [ -n "$WALLPAPER" ] && [ -f "$WALLPAPER" ]; then
+                /bin/matugen image "$WALLPAPER" --source-color-index 0
+            fi
+        fi
+    fi
+
     # --- 7. JSON OUTPUT ---
     jq -n -c \
         --arg title "$title" \

--- a/.config/hypr/scripts/quickshell/music/music_info.sh
+++ b/.config/hypr/scripts/quickshell/music/music_info.sh
@@ -144,19 +144,7 @@ if [ "$STATUS" = "Playing" ] || [ "$STATUS" = "Paused" ]; then
     fi
 
     # --- 6.5. Matugen Colors ---
-    if { [ "$STATUS" = "Playing" ] || [ "$STATUS" = "Paused" ]; } && [ -f "$displayArt" ]; then
-        /bin/matugen image "$displayArt" --source-color-index 0
-    else
-        if [ -e ~/.cache/current_wallpaper.png ]; then
-            /bin/matugen image ~/.cache/current_wallpaper.png --source-color-index 0
-        else
-            WALLPAPER=$(awww query | sed -n 's/.*image: //p' | head -n1)
-
-            if [ -n "$WALLPAPER" ] && [ -f "$WALLPAPER" ]; then
-                /bin/matugen image "$WALLPAPER" --source-color-index 0
-            fi
-        fi
-    fi
+    /bin/matugen image "$displayArt" --source-color-index 0
 
     # --- 7. JSON OUTPUT ---
     jq -n -c \
@@ -199,6 +187,17 @@ if [ "$STATUS" = "Playing" ] || [ "$STATUS" = "Paused" ]; then
 
 else
     # --- FALLBACK (Stopped) ---
+    # Set matugen colors back to wallpaper
+    WALLPAPER_CACHE="$(readlink -f ~/.cache/current_wallpaper.* 2>/dev/null | head -n1)"
+    if [ -n "$WALLPAPER_CACHE" ] && [ -f "$WALLPAPER_CACHE" ]; then
+        /bin/matugen image "$WALLPAPER_CACHE" --source-color-index 0
+    else
+        WALLPAPER=$(awww query | sed -n 's/.*image: //p' | head -n1)
+        if [ -n "$WALLPAPER" ] && [ -f "$WALLPAPER" ]; then
+            /bin/matugen image "$WALLPAPER" --source-color-index 0
+        fi
+    fi
+
     # Restore last known position so the widget does not snap to 00:00
     if [ -f "$STATE_FILE" ]; then
         last_pos_sec=$(jq -r '.pos_sec' "$STATE_FILE")

--- a/.config/hypr/scripts/quickshell/wallpaper/WallpaperPicker.qml
+++ b/.config/hypr/scripts/quickshell/wallpaper/WallpaperPicker.qml
@@ -270,6 +270,7 @@ Item {
             pkill mpvpaper || true
             
             ${wallpaperCmd}
+            ln -sfn "${escOriginal}" ~/.cache/current_wallpaper.png
             ( matugen image "${escThumb}" || true; bash "${escReload}" || true ) &
         `;
         Quickshell.execDetached(["bash", "-c", fullScript]);

--- a/.config/hypr/scripts/quickshell/wallpaper/WallpaperPicker.qml
+++ b/.config/hypr/scripts/quickshell/wallpaper/WallpaperPicker.qml
@@ -265,13 +265,14 @@ Item {
             `;
         }
 
+        const ext = escOriginal.split('.').pop();
         const fullScript = `
             cp "${isVideo ? escThumb : escOriginal}" /tmp/lock_bg.png || true
             pkill mpvpaper || true
-            
+
             ${wallpaperCmd}
-            ln -sfn "${escOriginal}" ~/.cache/current_wallpaper.png
-            ( matugen image "${escThumb}" || true; bash "${escReload}" || true ) &
+            ln -sfn "${escOriginal}" ~/.cache/current_wallpaper.${ext}
+            ( matugen image "${escThumb}" --source-color-index 0 || true; bash "${escReload}" || true ) &
         `;
         Quickshell.execDetached(["bash", "-c", fullScript]);
     }


### PR DESCRIPTION
if music is playing or paused (not stopped) then the musics colors will be the matugen colors instead of the wallpaper. once the music is stopped the matugen colors go back to the wallpaper colors either using ~/.cache/current_wallpaper.png that WallpaperPicker.qml now symlinks or uses awww query to get the first monitors wallpaper path.

Pretty simple and looks cool.