### PR TITLE
Add 'parch' to supported OS list in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ else
 fi
 
 case "$DETECTED_OS" in
-    arch|endeavouros|manjaro|cachyos)
+    arch|endeavouros|manjaro|cachyos|parch)
         OS="$DETECTED_OS"
         ;;
     fedora)


### PR DESCRIPTION
Parch is based on Arch, so this script is completely stable on it, and based on manual testing on Parch, Parch was also added to the list of operating systems.