### PR TITLE
fix(quickactions/Timer): pause animations when widget is hidden

### DIFF
--- a/.config/hypr/scripts/quickshell/quickactions/Timer.qml
+++ b/.config/hypr/scripts/quickshell/quickactions/Timer.qml
@@ -110,6 +110,12 @@ Item {
     property bool isTimerRunning: stateCache.timerTargetEpoch > 0
     property bool isTimerIdle: !isTimerRunning && stateCache.timerRemainingMs === stateCache.timerPresetMs
 
+    // Visibility gate — `parent` is the Loader from Floating.qml whose `visible`
+    // is bound to `index === activeIndex && expandProgress > 0.01`. Falling back
+    // to true keeps the module functional if loaded outside that Loader.
+    property bool widgetVisible: parent !== null && parent.visible !== undefined ? parent.visible : true
+    property bool anyTimerActive: stateCache.timerTargetEpoch > 0 || stateCache.swStartEpoch > 0 || stateCache.pomoTargetEpoch > 0
+
     property var interceptedShortcuts: {
         let arr = ["Return", "Enter"];
         if (stateCache.activeMode === 0 && isTimerIdle) {
@@ -165,7 +171,7 @@ Item {
             id: globalTicker
             interval: 32
             repeat: true
-            running: root.visible
+            running: root.widgetVisible && root.anyTimerActive
             onTriggered: {
                 let now = Date.now();
                 
@@ -347,7 +353,7 @@ Item {
                     property real downOffset: 0
 
                     SequentialAnimation on upOffset {
-                        running: isSelected && root.isTimerIdle
+                        running: isSelected && root.isTimerIdle && root.widgetVisible
                         loops: Animation.Infinite
                         NumberAnimation { to: -root.s(4); duration: 500; easing.type: Easing.InOutSine }
                         NumberAnimation { to: 0; duration: 500; easing.type: Easing.InOutSine }
@@ -355,7 +361,7 @@ Item {
                     onIsSelectedChanged: if (!isSelected) { upOffset = 0; downOffset = 0; }
 
                     SequentialAnimation on downOffset {
-                        running: isSelected && root.isTimerIdle
+                        running: isSelected && root.isTimerIdle && root.widgetVisible
                         loops: Animation.Infinite
                         NumberAnimation { to: root.s(4); duration: 500; easing.type: Easing.InOutSine }
                         NumberAnimation { to: 0; duration: 500; easing.type: Easing.InOutSine }


### PR DESCRIPTION
## Summary

The new `Timer.qml` quickaction has two persistent animation sources that keep running even with the Floating sidebar collapsed, causing significant idle CPU usage:

1. **`globalTicker`** (32 ms repeating Timer at line 168) was gated on `root.visible`. `root` is the Item itself — `root.visible` defaults to `true` and is never toggled. The visibility gate that matters lives on the `Loader` inside `Floating.qml` (`visible: index === activeIndex && expandProgress > 0.01`), not on the loaded Item.
2. **The two `SequentialAnimation` loops** on `TimerSegment.upOffset` / `downOffset` (lines 350, 358) were gated only on `isSelected && isTimerIdle`. `activeEditSegment` defaults to `1` so the Minutes segment is `isSelected` from boot, and `isTimerIdle` is `true` at rest — so both `loops: Animation.Infinite` animations ran forever.

QML keeps animations alive on hidden items — only the repaint is skipped — so those bobbing animations kept invalidating layout in the background, and the ticker kept firing at ~31 Hz, even on monitors where the Floating sidebar was never expanded.

## Fix

Adopt the same pattern that landed in `SystemUsage.qml` in e47d700:

- Add `property bool widgetVisible: parent !== null && parent.visible !== undefined ? parent.visible : true` — `parent` of the loaded Item is the `Loader`, whose `visible` is the right gate. Falls back to `true` if the module is loaded outside a Loader.
- Add `property bool anyTimerActive` covering the three modes.
- Change `globalTicker.running` to `root.widgetVisible && root.anyTimerActive`.
- Append `&& root.widgetVisible` to both `SequentialAnimation` gates in `TimerSegment`.

Behavior preserved: when Timer/Stopwatch/Pomodoro start, `anyTimerActive` flips true and the ticker resumes; the epoch-based timer state means closing the sidebar mid-run does not lose time — the next tick after reopening computes `targetEpoch - Date.now()` and the display catches up.

## Measured impact

Setup: dual 2560×1440 @ 170 Hz, Intel Iris Xe (Raptor Lake-P), Hyprland 0.54 + Quickshell shell from this repo.

| Process | Before | After | Δ |
|---|---|---|---|
| `quickshell -p Floating.qml` | ~22 % | ~9 % | **−61 %** |
| Hyprland | ~33 % | ~23 % | −30 % |

The Hyprland drop is downstream — fewer scenegraph invalidations from the Floating panel mean fewer compositor frames.

## Test plan

- [x] Apply patch, reload Quickshell, confirm Floating CPU drops in `top`.
- [x] Open Timer tab, start a timer, confirm countdown ticks.
- [x] Close sidebar mid-countdown, reopen — display catches up to true elapsed.
- [x] Switch to Stopwatch, start, close sidebar, reopen — same behavior.
- [x] Pomodoro: same.
- [x] Edit timer preset (Up/Down on Minutes segment) — bobbing arrows still animate when sidebar is open.