### PR TITLE
feat: cyclic prev/next workspace switching

### DIFF
--- a/.config/hypr/scripts/qs_manager.sh
+++ b/.config/hypr/scripts/qs_manager.sh
@@ -24,6 +24,27 @@ if [[ "$ACTION" =~ ^[0-9]+$ ]]; then
     exit 0
 fi
 
+if [[ "$ACTION" == "prev" || "$ACTION" == "next" ]]; then
+    read CURRENT WORKSPACE_COUNT < <(
+        hyprctl activeworkspace -j 2>/dev/null |
+        jq -r --slurpfile cfg <(cat "$HOME/.config/hypr/settings.json" 2>/dev/null || echo '{}') \
+            '"\(.id // empty) \($cfg[0].workspaceCount // 10)"'
+    )
+    [[ "$CURRENT" =~ ^[0-9]+$ ]] || exit 1
+    (( WORKSPACE_COUNT >= 1 )) || WORKSPACE_COUNT=8
+
+    if [[ "$ACTION" == "next" ]]; then
+        TARGET_WS=$(( CURRENT % WORKSPACE_COUNT + 1 ))
+    else
+        TARGET_WS=$(( (CURRENT - 2 + WORKSPACE_COUNT) % WORKSPACE_COUNT + 1 ))
+    fi
+
+    quickshell -p "$SHELL_QML_PATH" ipc call main handleCommand "close" "" "" >/dev/null 2>&1
+    CMD="workspace $TARGET_WS"
+    [[ "$TARGET" == "move" ]] && CMD="movetoworkspace $TARGET_WS"
+    hyprctl --batch "dispatch $CMD" >/dev/null 2>&1
+    exit 0
+fi
 # -----------------------------------------------------------------------------
 # SLOW PATH: Everything below only runs for non-workspace actions
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
поддержка команд `prev` и `next` в fast-path блоке переключения воркспейсов в qs_manager.sh
qs_manager.sh next > на следующий воркспейс
qs_manager.sh prev >  на предыдущий  
qs_manager.sh next move > перенести окно на следующий  
qs_manager.sh prev move > на предыдущий
workspaceCount читается из settings.json, фолбэк - 8  
переключение циклическое: после последнего - снова к первому, с первого назад - к последнему
