### PR TITLE
Enable screen sharing support on Wayland using xdg-desktop-portal-wlr

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -165,7 +165,7 @@ ARCH_PKGS=(
     "grim" "playerctl" "satty" "yq" "xdg-desktop-portal-gtk" "slurp" "mpvpaper"
     "wmctrl" "power-profiles-daemon" "easyeffects" "swayosd-git" "nautilus" "lsp-plugins" "hyprpolkitagent"
     "qt5-wayland" "qt5-quickcontrols" "qt5-quickcontrols2" "qt5-graphicaleffects" "qt6-wayland"
-    "qt5ct" "qt6ct" "gpu-screen-recorder" "adw-gtk-theme"
+    "qt5ct" "qt6ct" "gpu-screen-recorder" "adw-gtk-theme" "xdg-desktop-portal-wlr"
 )
 
 PKGS=("${ARCH_PKGS[@]}")


### PR DESCRIPTION
## Summary

Added `xdg-desktop-portal-wlr` to enable proper screen and display capture support for Wayland environments.

## Changes

* Installed and configured `xdg-desktop-portal-wlr`
* Enabled desktop screen sharing support for applications such as Google Meet
* Fixed issue where screen sharing was previously unavailable under Wayland

## Result

Users can now successfully share their entire desktop/screen during video conferencing sessions and other screen capture workflows.
