### PR TITLE
Fix: lock system before suspending via inhibit_sleep

### DIFF
--- a/.config/hypr/hypridle.conf
+++ b/.config/hypr/hypridle.conf
@@ -20,6 +20,7 @@ general {
     lock_cmd = quickshell -p ~/.config/hypr/scripts/quickshell/Lock.qml
     before_sleep_cmd = loginctl lock-session
     after_sleep_cmd = hyprctl dispatch dpms on
+    inhibit_sleep = 3
 }
 
 listener {


### PR DESCRIPTION
Previously, the system suspended before locking, briefly exposing the desktop upon waking. Adding inhibit_sleep ensures the system locks immediately when the lid is closed, before suspending.