### PR TITLE
Fixed video screen capture issue caused by XDG portal.

### DIFF
--- a/.config/hypr/scripts/quickshell/ScreenshotOverlay.qml
+++ b/.config/hypr/scripts/quickshell/ScreenshotOverlay.qml
@@ -38,29 +38,6 @@ PanelWindow {
 
     onIsVideoModeChanged: {
         Quickshell.execDetached(["bash", "-c", "echo '" + (root.isVideoMode ? "true" : "false") + "' > " + paths.getCacheDir("screenshot") + "/video_mode"]);
-        
-        // Smart Geometry Snapping for Portal Support
-        if (root.isVideoMode) {
-            root.preStartX = root.startX; 
-            root.preStartY = root.startY;
-            root.preEndX = root.endX; 
-            root.preEndY = root.endY;
-            
-            root.startX = 0; 
-            root.startY = 0; 
-            root.endX = root.width; 
-            root.endY = root.height;
-            root.hasSelection = true;
-        } else {
-            root.startX = root.preStartX; 
-            root.startY = root.preStartY;
-            root.endX = root.preEndX; 
-            root.endY = root.preEndY;
-            
-            if (Math.abs(root.endX - root.startX) < 10 || Math.abs(root.endY - root.startY) < 10) {
-                root.hasSelection = false;
-            }
-        }
     }
     
     // --- Audio State Persistence ---
@@ -138,7 +115,7 @@ PanelWindow {
     ListModel { id: qrModel }
 
     function saveCache() {
-        if (root.hasSelection && !root.isVideoMode) {
+        if (root.hasSelection) {
             let data = Math.round(root.selX) + "," + Math.round(root.selY) + "," + Math.round(root.selW) + "," + Math.round(root.selH);
             Quickshell.execDetached(["bash", "-c", "echo '" + data + "' > " + paths.getCacheDir("screenshot") + "/geometry"]);
         }
@@ -157,7 +134,6 @@ PanelWindow {
     }
 
     function toggleMaximize() {
-        if (root.isVideoMode) return;
         if (!isMaximized) {
             preStartX = root.startX; preStartY = root.startY;
             preEndX = root.endX; preEndY = root.endY;
@@ -256,7 +232,7 @@ PanelWindow {
             Behavior on opacity { NumberAnimation { duration: 150 } }
             Text {
                 anchors.centerIn: parent
-                text: root.isVideoMode ? "Click Record (Portal handles area selection)" : "Select region to capture"
+                text: root.isVideoMode ? "Draw region to record" : "Select region to capture"
                 font.family: "JetBrains Mono"; font.weight: Font.DemiBold; font.pixelSize: s(24); color: _theme.text
             }
         }
@@ -303,7 +279,7 @@ PanelWindow {
     component Handle: Rectangle {
         width: s(20); height: s(20); radius: s(10)
         color: root.handleColor; border.color: root.accentColor; border.width: s(4)
-        visible: (root.hasSelection || root.isSelecting) && !root.isScanningQr && !root.showQrPopup && !root.isVideoMode; z: 10
+        visible: (root.hasSelection || root.isSelecting) && !root.isScanningQr && !root.showQrPopup; z: 10
     }
     Handle { x: root.selX - width / 2; y: root.selY - height / 2 } 
     Handle { x: root.selX + root.selW - width / 2; y: root.selY - height / 2 } 
@@ -339,7 +315,6 @@ PanelWindow {
         }
 
         onPositionChanged: (mouse) => {
-            if (root.isVideoMode) { cursorShape = Qt.ArrowCursor; return; }
             let mode = root.isSelecting ? root.interactionMode : getInteractionMode(mouse.x, mouse.y, mouse.modifiers)
             switch(mode) {
                 case 2: cursorShape = Qt.ClosedHandCursor; break;
@@ -371,7 +346,6 @@ PanelWindow {
 
         onPressed: (mouse) => {
             if (mouse.button === Qt.RightButton) { Qt.quit(); return; }
-            if (root.isVideoMode) return; 
 
             root.isScanningQr = false;
             root.showQrPopup = false;

--- a/.config/hypr/scripts/screenshot.sh
+++ b/.config/hypr/scripts/screenshot.sh
@@ -229,8 +229,14 @@ if [ "$FULL_MODE" = true ] || [ -n "$GEOMETRY" ]; then
         [ -n "$MIC_DEVICE" ] && [ "$MIC_DEVICE" != "null" ] && MIC_DEV="$MIC_DEVICE" || MIC_DEV=$(pactl get-default-source 2>/dev/null)
         MIC_DEV="${MIC_DEV:-default}"
 
-        # Reverted back to the portal method for reliable security clearance
-        GSR_ARGS=(-w "portal" -c "mp4" -f "60" -ac "aac")
+        GEOM_POS="${GEOMETRY%% *}"
+        GEOM_SIZE="${GEOMETRY##* }"
+        GEOM_X="${GEOM_POS%%,*}"
+        GEOM_Y="${GEOM_POS##*,}"
+        GEOM_W="${GEOM_SIZE%%x*}"
+        GEOM_H="${GEOM_SIZE##*x}"
+        GSR_REGION="${GEOM_W}x${GEOM_H}+${GEOM_X}+${GEOM_Y}"
+        GSR_ARGS=(-w region -region "$GSR_REGION" -c "mp4" -f "60" -ac "aac")
 
         AUDIO_MIX=""
 


### PR DESCRIPTION
gpu-screen-recorder's portal mode fails on AMD GFX11 (Aquamarine) because Hyprland allocates screencopy DMA-BUFs with DCC modifiers that EGL cannot import. Switch to -w region so GSR captures the user-drawn selection directly, bypassing the XDG portal entirely. Update the overlay to allow region selection in video mode (removes portal-era restrictions on mouse interaction, handles, maximize, and geometry caching).