### PR TITLE
Add 'fullscreen' to dispatchers in settings

### DIFF
--- a/.config/hypr/scripts/quickshell/settings/SettingsPopup.qml
+++ b/.config/hypr/scripts/quickshell/settings/SettingsPopup.qml
@@ -507,7 +507,7 @@ Item {
         }
     }
     property var bindTypes: ["bind", "binde", "bindl", "bindel", "bindm"]
-    property var dispatchers: ["exec", "exec-once", "dispatch", "workspace", "movetoworkspace", "movewindow", "resizeactive", "movefocus", "togglefloating", "killactive"]
+    property var dispatchers: ["exec", "exec-once", "dispatch", "workspace", "movetoworkspace", "movewindow", "resizeactive", "movefocus", "togglefloating", "killactive", "fullscreen"]
 
     function saveAllKeybinds() {
         let bindsArray = [];


### PR DESCRIPTION
This is neccessary for toggeling fullscreen over keybindings

<img width="498" height="230" alt="image" src="https://github.com/user-attachments/assets/42a02eba-7dfa-489b-b3de-2124c3ba1a6d" />
