### PR TITLE
fix(topbar): prevent watcher process leaks

### DIFF
--- a/.config/hypr/scripts/quickshell/TopBar.qml
+++ b/.config/hypr/scripts/quickshell/TopBar.qml
@@ -447,7 +447,7 @@ Variants {
                     }
                 }
             }
-            Process { id: kbWaiter; command: ["bash", "-c", "~/.config/hypr/scripts/quickshell/watchers/kb_wait.sh"]; onExited: { kbPoller.running = false; kbPoller.running = true; } }
+            Process { id: kbWaiter; command: ["setpriv", "--pdeathsig", "TERM", "bash", Quickshell.env("HOME") + "/.config/hypr/scripts/quickshell/watchers/kb_wait.sh"]; onExited: { kbPoller.running = false; kbPoller.running = true; } }
 
             Process {
                 id: audioPoller; running: true
@@ -470,7 +470,7 @@ Variants {
                     }
                 }
             }
-            Process { id: audioWaiter; command: ["bash", "-c", "~/.config/hypr/scripts/quickshell/watchers/audio_wait.sh"]; onExited: { audioPoller.running = false; audioPoller.running = true; } }
+            Process { id: audioWaiter; command: ["setpriv", "--pdeathsig", "TERM", "bash", Quickshell.env("HOME") + "/.config/hypr/scripts/quickshell/watchers/audio_wait.sh"]; onExited: { audioPoller.running = false; audioPoller.running = true; } }
 
             Process {
                 id: networkPoller; running: true
@@ -492,7 +492,7 @@ Variants {
                     }
                 }
             }
-            Process { id: networkWaiter; command: ["bash", "-c", "~/.config/hypr/scripts/quickshell/watchers/network_wait.sh"]; onExited: { networkPoller.running = false; networkPoller.running = true; } }
+            Process { id: networkWaiter; command: ["setpriv", "--pdeathsig", "TERM", "bash", Quickshell.env("HOME") + "/.config/hypr/scripts/quickshell/watchers/network_wait.sh"]; onExited: { networkPoller.running = false; networkPoller.running = true; } }
 
             Process {
                 id: btPoller; running: true
@@ -513,7 +513,7 @@ Variants {
                     }
                 }
             }
-            Process { id: btWaiter; command: ["bash", "-c", "~/.config/hypr/scripts/quickshell/watchers/bt_wait.sh"]; onExited: { btPoller.running = false; btPoller.running = true; } }
+            Process { id: btWaiter; command: ["setpriv", "--pdeathsig", "TERM", "bash", Quickshell.env("HOME") + "/.config/hypr/scripts/quickshell/watchers/bt_wait.sh"]; onExited: { btPoller.running = false; btPoller.running = true; } }
 
             Process {
                 id: batteryPoller; running: true
@@ -535,7 +535,7 @@ Variants {
                     }
                 }
             }
-            Process { id: batteryWaiter; command: ["bash", "-c", "~/.config/hypr/scripts/quickshell/watchers/battery_wait.sh"]; onExited: { batteryPoller.running = false; batteryPoller.running = true; } }
+            Process { id: batteryWaiter; command: ["setpriv", "--pdeathsig", "TERM", "bash", Quickshell.env("HOME") + "/.config/hypr/scripts/quickshell/watchers/battery_wait.sh"]; onExited: { batteryPoller.running = false; batteryPoller.running = true; } }
 
             Process {
                 id: weatherPoller

--- a/.config/hypr/scripts/quickshell/watchers/audio_wait.sh
+++ b/.config/hypr/scripts/quickshell/watchers/audio_wait.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE[0]}")/../../caching.sh"
-
 PIPE="$QS_RUN_DIR/qs_audio_wait_$$.fifo"
-mkfifo "$PIPE" 2>/dev/null
-
-trap 'rm -f "$PIPE"; kill $MONITOR_PID 2>/dev/null; exit 0' EXIT INT TERM
-
-# Run pactl isolated and capture its exact PID to prevent PipeWire connection exhaustion
-LC_ALL=C pactl subscribe 2>/dev/null > "$PIPE" &
+rm -f "$PIPE"; mkfifo "$PIPE"
+MONITOR_PID=""
+cleanup() {
+    trap - EXIT INT TERM HUP
+    rm -f "$PIPE"
+    [[ -z "${MONITOR_PID:-}" ]] || kill "$MONITOR_PID" 2>/dev/null || true
+    exit 0
+}
+trap cleanup EXIT INT TERM HUP
+LC_ALL=C setpriv --pdeathsig TERM pactl subscribe > "$PIPE" 2>/dev/null &
 MONITOR_PID=$!
-
-grep -m 1 -E "sink|server" < "$PIPE" > /dev/null
+while IFS= read -r line; do
+    lower="${line,,}"
+    [[ "$lower" == *sink* || "$lower" == *server* ]] && break
+done < "$PIPE"

--- a/.config/hypr/scripts/quickshell/watchers/battery_wait.sh
+++ b/.config/hypr/scripts/quickshell/watchers/battery_wait.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE[0]}")/../../caching.sh"
-
 PIPE="$QS_RUN_DIR/qs_battery_wait_$$.fifo"
-mkfifo "$PIPE" 2>/dev/null
-
-trap 'rm -f "$PIPE"; kill $MONITOR_PID 2>/dev/null; exit 0' EXIT INT TERM
-
-# Run udevadm isolated and capture its exact PID
-LC_ALL=C udevadm monitor --subsystem-match=power_supply 2>/dev/null > "$PIPE" &
+rm -f "$PIPE"; mkfifo "$PIPE"
+MONITOR_PID=""
+cleanup() {
+    trap - EXIT INT TERM HUP
+    rm -f "$PIPE"
+    [[ -z "${MONITOR_PID:-}" ]] || kill "$MONITOR_PID" 2>/dev/null || true
+    exit 0
+}
+trap cleanup EXIT INT TERM HUP
+LC_ALL=C setpriv --pdeathsig TERM udevadm monitor --subsystem-match=power_supply > "$PIPE" 2>/dev/null &
 MONITOR_PID=$!
-
-# Blocks until udevadm catches a change, OR 30 seconds pass (your failsafe).
-# Either way, when this line finishes, the trap fires and cleans up perfectly.
-timeout 10 grep -m 1 "change" < "$PIPE" > /dev/null
+deadline=$((SECONDS + 10))
+while (( SECONDS < deadline )); do
+    remaining=$((deadline - SECONDS))
+    IFS= read -r -t "$remaining" line || break
+    [[ "${line,,}" == *change* ]] && break
+done < "$PIPE"

--- a/.config/hypr/scripts/quickshell/watchers/bt_wait.sh
+++ b/.config/hypr/scripts/quickshell/watchers/bt_wait.sh
@@ -1,9 +1,23 @@
 #!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE[0]}")/../../caching.sh"
-
 PIPE="$QS_RUN_DIR/qs_bt_wait_$$.fifo"
-mkfifo "$PIPE" 2>/dev/null
-trap 'rm -f "$PIPE"; kill $(jobs -p) 2>/dev/null; exit 0' EXIT INT TERM
-LC_ALL=C dbus-monitor --system "type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',arg0='org.bluez.Device1'" 2>/dev/null | grep --line-buffered 'string "Connected"' > "$PIPE" &
-LC_ALL=C dbus-monitor --system "type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',arg0='org.bluez.Adapter1'" 2>/dev/null | grep --line-buffered 'string "Powered"' > "$PIPE" &
-read -r _ < "$PIPE"
+rm -f "$PIPE"; mkfifo "$PIPE"
+MONITOR_PIDS=()
+cleanup() {
+    trap - EXIT INT TERM HUP
+    rm -f "$PIPE"
+    for pid in "${MONITOR_PIDS[@]}"; do kill "$pid" 2>/dev/null || true; done
+    exit 0
+}
+trap cleanup EXIT INT TERM HUP
+LC_ALL=C setpriv --pdeathsig TERM dbus-monitor --system \
+"type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',arg0='org.bluez.Device1'" \
+> "$PIPE" 2>/dev/null &
+MONITOR_PIDS+=("$!")
+LC_ALL=C setpriv --pdeathsig TERM dbus-monitor --system \
+"type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',arg0='org.bluez.Adapter1'" \
+> "$PIPE" 2>/dev/null &
+MONITOR_PIDS+=("$!")
+while IFS= read -r line; do
+    [[ "$line" == *'string "Connected"'* || "$line" == *'string "Powered"'* ]] && break
+done < "$PIPE"

--- a/.config/hypr/scripts/quickshell/watchers/kb_wait.sh
+++ b/.config/hypr/scripts/quickshell/watchers/kb_wait.sh
@@ -1,15 +1,24 @@
 #!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE[0]}")/../../caching.sh"
-
 PIPE="$QS_RUN_DIR/qs_kb_wait_$$.fifo"
-mkfifo "$PIPE" 2>/dev/null
-trap 'rm -f "$PIPE"; kill $(jobs -p) 2>/dev/null; exit 0' EXIT INT TERM
-
-if [ -n "$HYPRLAND_INSTANCE_SIGNATURE" ]; then
-    LC_ALL=C socat -U - UNIX-CONNECT:$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock 2>/dev/null | grep --line-buffered "activelayout>>" > "$PIPE" &
+rm -f "$PIPE"; mkfifo "$PIPE"
+MONITOR_PID=""
+cleanup() {
+    trap - EXIT INT TERM HUP
+    rm -f "$PIPE"
+    [[ -z "${MONITOR_PID:-}" ]] || kill "$MONITOR_PID" 2>/dev/null || true
+    exit 0
+}
+trap cleanup EXIT INT TERM HUP
+if [[ -n "${HYPRLAND_INSTANCE_SIGNATURE:-}" ]]; then
+    LC_ALL=C setpriv --pdeathsig TERM socat -U - \
+    "UNIX-CONNECT:$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock" \
+    > "$PIPE" 2>/dev/null &
+    MONITOR_PID=$!
+    while IFS= read -r line; do
+        [[ "$line" == *"activelayout>>"* ]] && break
+    done < "$PIPE"
 else
-    sleep 10 > "$PIPE" &
+    sleep 10
 fi
-
-read -r _ < "$PIPE"
 sleep 0.05

--- a/.config/hypr/scripts/quickshell/watchers/network_wait.sh
+++ b/.config/hypr/scripts/quickshell/watchers/network_wait.sh
@@ -1,16 +1,23 @@
 #!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE[0]}")/../../caching.sh"
-
 PIPE="$QS_RUN_DIR/qs_network_wait_$$.fifo"
-mkfifo "$PIPE" 2>/dev/null
-
-# Trap ensures we delete the FIFO and specifically kill nmcli, leaving no zombie processes
-trap 'rm -f "$PIPE"; kill $MONITOR_PID 2>/dev/null; exit 0' EXIT INT TERM
-
-# Run nmcli completely isolated and capture its exact PID
-LC_ALL=C nmcli monitor 2>/dev/null > "$PIPE" &
+rm -f "$PIPE"; mkfifo "$PIPE"
+MONITOR_PID=""
+cleanup() {
+    trap - EXIT INT TERM HUP
+    rm -f "$PIPE"
+    [[ -z "${MONITOR_PID:-}" ]] || kill "$MONITOR_PID" 2>/dev/null || true
+    exit 0
+}
+trap cleanup EXIT INT TERM HUP
+LC_ALL=C setpriv --pdeathsig TERM nmcli monitor > "$PIPE" 2>/dev/null &
 MONITOR_PID=$!
-
-# Grep blocks until it reads the first match from the FIFO, then exits.
-# Exiting triggers the trap, immediately killing nmcli and ending the script.
-grep -m 1 -iwE "connected|disconnected|enabled|disabled|activated|deactivated|available|unavailable" < "$PIPE" > /dev/null
+while IFS= read -r line; do
+    lower="${line,,}"
+    if [[ "$lower" == *connected* || "$lower" == *disconnected* ||
+          "$lower" == *enabled* || "$lower" == *disabled* ||
+          "$lower" == *activated* || "$lower" == *deactivated* ||
+          "$lower" == *available* || "$lower" == *unavailable* ]]; then
+        break
+    fi
+done < "$PIPE"


### PR DESCRIPTION
Addresses the watcher/socket/monitor portion of #89.

## Problem

TopBar watcher helpers spawn long-lived monitor subprocesses (`nmcli monitor`, `pactl subscribe`, BlueZ `dbus-monitor`, Hyprland `socat`, and `udevadm monitor`). During Quickshell reload/termination, watcher shells or monitor children can survive and become adopted by `systemd --user`.

## Changes

- launch the five watcher roots with `setpriv --pdeathsig TERM`;
- launch each long-running monitor child with its own parent-death signal;
- retain cleanup traps;
- replace blocking external/pipeline `grep` waits with Bash `read` loops;
- preserve the existing event filtering behavior.

## Validation

Before the patch, stale watcher/monitor generations were observed under `systemd --user`.

After intentionally terminating Quickshell:

```text
WATCHER ROOTS AFTER KILL:
NONE

QUICKSHELL MONITORS AFTER KILL:
NONE

SYSTEMD-ADOPTED WATCHERS:
NONE
```

A clean restart then produced exactly one of each TopBar watcher with no Quickshell-related orphan detected.

This PR deliberately scopes itself to the long-lived watcher subtrees; it does not claim to fix every unrelated `inotifywait` launch in the repo.
